### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -9,7 +9,10 @@ on:
   pull_request:
   schedule:
     - cron: "15 4 * * *"
-  
+
+permissions:
+  contents: read
+  packages: write
 
 jobs:
   build:


### PR DESCRIPTION
Potential fix for [https://github.com/adamus1red/nut-upsd/security/code-scanning/2](https://github.com/adamus1red/nut-upsd/security/code-scanning/2)

Add an explicit `permissions` block to `.github/workflows/docker-image.yml` at the workflow root (right after `on:` section, before `jobs:`), so all jobs inherit least-privilege permissions.  
For this workflow’s current behavior, the best-fit minimal explicit permissions are:

- `contents: read` (for checkout/metadata access)
- `packages: write` (required to push images to GHCR on non-PR events)

This preserves existing functionality (including push on branch/tag/schedule) while removing reliance on potentially over-privileged defaults.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
